### PR TITLE
Allow to overwrite the ContainerName using a Container Environment Variable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -62,6 +62,8 @@ Bug Handling
 
 * Fixed visibility of synchronous decoders in reports (#1312).
 
+* Fixed hang on SandboxFilter termination (#1509)
+
 * More ProcessInput/ProcessDirectoryInput retry logic fixes (#1412 & #1418).
 
 * ProcessInput fixed to no longer leak decoder goroutines when reconfigured

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -86,6 +86,13 @@ Bug Handling
 Bug Handling
 ------------
 
+* Correctly honor "user-agent" heading config in HttpInput (#1520).
+
+* Removed state from PluginMaker to remove race conditions during plugin
+  construction (#1532).
+
+* Get decoder lock before cleaning up decoders during pipeline shutdown to
+  avoid race condition panics during exit (#1531).
 
 0.9.2 (2015-04-22)
 ==================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@
 Bug Handling
 ------------
 
+* Correctly honor "user-agent" heading config in HttpInput (#1520).
 
 0.9.2 (2015-04-22)
 ==================

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Bug Handling
 
 * Correctly honor "user-agent" heading config in HttpInput (#1520).
 
+* Removed state from PluginMaker to remove race conditions during plugin
+  construction (#1532).
+
 0.9.2 (2015-04-22)
 ==================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -75,6 +75,9 @@ Bug Handling
 * Switch from unmaintained `crowdmob` fork of GoAMZ dependency to `AdRoll`
   (#1458).
 
+* Added ability to reconnect after lost connection in `heka-flood` (#1536).
+
+
 0.9.3 (2015-??-??)
 ==================
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,6 +57,8 @@ Features
 
 * Added `graphite` module with helpers allowing to generate graphite metrics for counters and timeseries (#1461).
 
+* Added SSL/TLS support to HttpListenInput (#1534)
+
 Bug Handling
 ------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,9 @@ Bug Handling
 * Switch from unmaintained `crowdmob` fork of GoAMZ dependency to `AdRoll`
   (#1458).
 
+* Added ability to reconnect after lost connection in `heka-flood` (#1536).
+
+
 0.9.3 (2015-??-??)
 ==================
 

--- a/docs/source/config/inputs/httplisten.rst
+++ b/docs/source/config/inputs/httplisten.rst
@@ -47,6 +47,16 @@ Config:
 - request_headers ([]string):
     Add additional request headers as message fields. Defaults to empty list.
 
+.. versionadded:: 0.10
+
+- use_tls (bool):
+    Specifies whether or not SSL/TLS encryption should be used for the TCP
+    connections. Defaults to false.
+- tls (TlsConfig):
+    A sub-section that specifies the settings to be used for any SSL/TLS
+    encryption. This will only have any impact if `use_tls` is set to true.
+    See :ref:`tls`.
+ 
 Example:
 
 .. code-block:: ini

--- a/docs/source/developing/testing.rst
+++ b/docs/source/developing/testing.rst
@@ -84,6 +84,16 @@ Configuration Variables
 - max_message_size (uint32):
     The maximum size of the message that will be sent by heka-flood.
 
+.. versionadded:: 0.10
+
+- reconnect_on_error (bool):
+    Defines if `heka-flood` should try to reconnect with backend after connection error. Exits if reconnect_on_error is set to false.
+    Defaults to false.
+
+- reconnect_interval (int):
+    Specifies interval (in seconds) after which `heka-flood` will try to recreate connection with backend.
+    Defaults to 5s.
+
 Example
 
 .. code-block:: ini

--- a/pipeline/config.go
+++ b/pipeline/config.go
@@ -19,20 +19,19 @@ package pipeline
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/go-uuid/uuid"
 	"errors"
 	"fmt"
-	"github.com/bbangert/toml"
-	"github.com/mozilla-services/heka/message"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"reflect"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
+
+	"code.google.com/p/go-uuid/uuid"
+	"github.com/bbangert/toml"
 )
 
 const (
@@ -273,7 +272,7 @@ func (self *PipelineConfig) Decoder(name string) (decoder Decoder, ok bool) {
 		return
 	}
 
-	plugin, err := maker.Make()
+	plugin, _, err := maker.Make()
 	if err != nil {
 		return nil, false
 	}
@@ -332,7 +331,7 @@ func (self *PipelineConfig) Encoder(baseName, fullName string) (Encoder, bool) {
 		return nil, false
 	}
 
-	plugin, err := maker.Make()
+	plugin, _, err := maker.Make()
 	self.makersLock.RUnlock()
 	if err != nil {
 		msg := fmt.Sprintf("Error creating encoder '%s': %s", fullName, err.Error())
@@ -477,10 +476,10 @@ type RetryOptions struct {
 
 var unknownOptionRegex = regexp.MustCompile("^Configuration contains key \\[(?P<key>\\S+)\\]")
 
-// Uses reflection to extract an attribute value from an arbitrary struct type
-// that may or may not actually have the attribute, returning a provided
-// default if the provided object is not a struct or if the attribute doesn't
-// exist.
+// getAttr uses reflection to extract an attribute value from an arbitrary
+// struct type that may or may not actually have the attribute, returning a
+// provided default if the provided object is not a struct or if the attribute
+// doesn't exist.
 func getAttr(ob interface{}, attr string, default_ interface{}) (ret interface{}) {
 	ret = default_
 	obVal := reflect.ValueOf(ob)
@@ -494,6 +493,25 @@ func getAttr(ob interface{}, attr string, default_ interface{}) (ret interface{}
 		return
 	}
 	return attrVal.Interface()
+}
+
+// getDefaultBool expects the name of a boolean setting and will extract and
+// return the struct's default value for the setting, as a boolean pointer.
+func getDefaultBool(ob interface{}, name string) (*bool, error) {
+	defaultValue := getAttr(ob, name, false)
+	switch defaultValue := defaultValue.(type) {
+	case bool:
+		return &defaultValue, nil
+	case *bool:
+		if defaultValue == nil {
+			b := false
+			defaultValue = &b
+		}
+		return defaultValue, nil
+	}
+	// If you hit this then a non-boolean config setting is conflicting
+	// with one of Heka's defined boolean settings.
+	return nil, fmt.Errorf("%s config setting must be boolean", name)
 }
 
 // Used internally to log and record plugin config loading errors.
@@ -550,435 +568,6 @@ func getDefaultRetryOptions() RetryOptions {
 	}
 }
 
-type PluginMaker interface {
-	Name() string
-	Type() string
-	Category() string
-	Config() interface{}
-	PrepConfig() error
-	Make() (Plugin, error)
-	MakeRunner(name string) (PluginRunner, error)
-}
-
-// MutableMaker is for consumers that want to customize the behavior of the
-// PluginMaker in "bad touch" ways, use at your own risk. Both interfaces are
-// implemented by the same struct, so a PluginMaker can be turned into a
-// MutableMaker via type coersion.
-type MutableMaker interface {
-	PluginMaker
-	SetConfig(config interface{})
-	CommonTypedConfig() interface{}
-	SetCommonTypedConfig(config interface{})
-	SetName(name string)
-	SetType(typ string)
-	SetCategory(category string)
-}
-
-type pluginMaker struct {
-	name              string
-	category          string
-	tomlSection       toml.Primitive
-	commonConfig      CommonConfig
-	commonTypedConfig interface{}
-	pConfig           *PipelineConfig
-	constructor       func() interface{}
-	configStruct      interface{}
-	configPrepped     bool
-	plugin            Plugin
-}
-
-// NewPluginMaker creates and returns a PluginMaker that can generate running
-// plugins for the provided TOML configuration. It will load the plugin type
-// and extract any of the Heka-defined common config for the plugin before
-// returning.
-func NewPluginMaker(name string, pConfig *PipelineConfig, tomlSection toml.Primitive) (
-	PluginMaker, error) {
-
-	// Create the maker, extract plugin type, and make sure the plugin type
-	// exists.
-	maker := &pluginMaker{
-		name:         name,
-		tomlSection:  tomlSection,
-		commonConfig: CommonConfig{},
-		pConfig:      pConfig,
-	}
-
-	var err error
-	if err = toml.PrimitiveDecode(tomlSection, &maker.commonConfig); err != nil {
-		return nil, fmt.Errorf("can't decode common config for '%s': %s", name, err)
-	}
-	if maker.commonConfig.Typ == "" {
-		maker.commonConfig.Typ = name
-	}
-	constructor, ok := AvailablePlugins[maker.commonConfig.Typ]
-	if !ok {
-		return nil, fmt.Errorf("No registered plugin type: %s", maker.commonConfig.Typ)
-	}
-	maker.constructor = constructor
-
-	// Extract plugin category and any category-specific common (i.e. Heka
-	// defined) configuration.
-	maker.category = getPluginCategory(maker.commonConfig.Typ)
-	if maker.category == "" {
-		return nil, errors.New("Unrecognized plugin category")
-	}
-
-	switch maker.category {
-	case "Input":
-		commonInput := CommonInputConfig{
-			Retries: getDefaultRetryOptions(),
-		}
-		err = toml.PrimitiveDecode(tomlSection, &commonInput)
-		maker.commonTypedConfig = commonInput
-	case "Filter", "Output":
-		commonFO := CommonFOConfig{
-			Retries: getDefaultRetryOptions(),
-		}
-		err = toml.PrimitiveDecode(tomlSection, &commonFO)
-		maker.commonTypedConfig = commonFO
-	case "Splitter":
-		commonSplitter := CommonSplitterConfig{}
-		err = toml.PrimitiveDecode(tomlSection, &commonSplitter)
-		maker.commonTypedConfig = commonSplitter
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("can't decode common %s config for '%s': %s",
-			strings.ToLower(maker.category), name, err)
-	}
-	return maker, nil
-}
-
-func (m *pluginMaker) Name() string {
-	return m.name
-}
-
-func (m *pluginMaker) Type() string {
-	return m.commonConfig.Typ
-}
-
-func (m *pluginMaker) Category() string {
-	return m.category
-}
-
-func (m *pluginMaker) SetName(name string) {
-	m.name = name
-}
-
-func (m *pluginMaker) SetType(typ string) {
-	m.commonConfig.Typ = typ
-}
-
-func (m *pluginMaker) SetCategory(category string) {
-	m.category = category
-}
-
-// makePlugin instantiates a plugin instance, provides name and pConfig to the
-// plugin if necessary, and returns the plugin.
-func (m *pluginMaker) makePlugin() Plugin {
-	plugin := m.constructor().(Plugin)
-	if wantsPConfig, ok := plugin.(WantsPipelineConfig); ok {
-		wantsPConfig.SetPipelineConfig(m.pConfig)
-	}
-	if wantsName, ok := plugin.(WantsName); ok {
-		wantsName.SetName(m.name)
-	}
-	return plugin
-}
-
-// makeConfig calls makePlugin to create a plugin instance, uses that instance
-// to create a config object, and then stores the plugin and the created
-// config object as attributes on the pluginMaker struct.
-
-func (m *pluginMaker) makeConfig() {
-	if m.plugin == nil {
-		m.plugin = m.makePlugin()
-	}
-	hasConfigStruct, ok := m.plugin.(HasConfigStruct)
-	if ok {
-		m.configStruct = hasConfigStruct.ConfigStruct()
-	} else {
-		// If we don't have a config struct, fall back to a PluginConfig.
-		m.configStruct = PluginConfig{}
-	}
-}
-
-// Config returns the PluginMaker's config struct, creating it if necessary.
-func (m *pluginMaker) Config() interface{} {
-	if m.configStruct == nil {
-		m.makeConfig()
-	}
-	return m.configStruct
-}
-
-func (m *pluginMaker) CommonTypedConfig() interface{} {
-	return m.commonTypedConfig
-}
-
-func (m *pluginMaker) SetConfig(config interface{}) {
-	m.configStruct = config
-}
-
-func (m *pluginMaker) SetCommonTypedConfig(config interface{}) {
-	m.commonTypedConfig = config
-}
-
-// PrepConfig generates a config struct for the plugin (instantiating an
-// instance of the plugin to do so, if necessary) and decodes the TOML config
-// into the generated struct.
-func (m *pluginMaker) PrepConfig() error {
-	if m.configPrepped {
-		// Already done, just return.
-		return nil
-	}
-
-	if m.configStruct == nil {
-		m.makeConfig()
-	} else if m.plugin == nil {
-		m.plugin = m.makePlugin()
-	}
-
-	if _, ok := m.plugin.(HasConfigStruct); !ok {
-		// If plugin doesn't implement HasConfigStruct then we're decoding
-		// into an empty PluginConfig object.
-		if err := toml.PrimitiveDecode(m.tomlSection, m.configStruct); err != nil {
-			return fmt.Errorf("can't decode config for '%s': %s ", m.name, err.Error())
-		}
-		m.configPrepped = true
-		return nil
-	}
-
-	// Use reflection to extract the fields (or TOML tag names, if available)
-	// of the values that Heka has already extracted so we know they're not
-	// required to be specified in the config struct.
-	hekaParams := make(map[string]interface{})
-	commons := []interface{}{m.commonConfig, m.commonTypedConfig}
-	for _, common := range commons {
-		if common == nil {
-			continue
-		}
-		rt := reflect.ValueOf(common).Type()
-		for i := 0; i < rt.NumField(); i++ {
-			sft := rt.Field(i)
-			kname := sft.Tag.Get("toml")
-			if len(kname) == 0 {
-				kname = sft.Name
-			}
-			hekaParams[kname] = true
-		}
-	}
-
-	// Finally decode the TOML into the struct. Use of PrimitiveDecodeStrict
-	// means that an error will be raised for any config options in the TOML
-	// that don't have corresponding attributes on the struct, delta the
-	// hekaParams that can be safely excluded.
-	err := toml.PrimitiveDecodeStrict(m.tomlSection, m.configStruct, hekaParams)
-	if err != nil {
-		matches := unknownOptionRegex.FindStringSubmatch(err.Error())
-		if len(matches) == 2 {
-			// We've got an unrecognized config option.
-			return fmt.Errorf("unknown config setting for '%s': %s", m.name, matches[1])
-		}
-		return err
-	}
-
-	m.configPrepped = true
-	return nil
-}
-
-// Make initializes a plugin instance using the prepped config struct and
-// returns the initialized plugin. If the config hasn't been prepped the
-// PrepConfig will be called. A new plugin may be instantiated, or a cached
-// plugin may be used, but Make will always return a "fresh" instance, i.e. it
-// will never return the same plugin instance twice.
-func (m *pluginMaker) Make() (Plugin, error) {
-	if !m.configPrepped {
-		// Our config struct hasn't been prepped.
-		if err := m.PrepConfig(); err != nil {
-			return nil, err
-		}
-	}
-
-	var plugin Plugin
-	if m.plugin == nil {
-		plugin = m.makePlugin()
-	} else {
-		plugin = m.plugin
-		m.plugin = nil
-	}
-
-	if err := plugin.Init(m.configStruct); err != nil {
-		return nil, fmt.Errorf("Initialization failed for '%s': %s", m.name, err)
-	}
-
-	return plugin, nil
-}
-
-// getDefaultBool expects the name of a boolean setting and will extract and
-// return the plugin's default value for the setting, as a boolean pointer.
-func (m *pluginMaker) getDefaultBool(name string) (*bool, error) {
-	defaultValue := getAttr(m.configStruct, name, false)
-	switch defaultValue := defaultValue.(type) {
-	case bool:
-		return &defaultValue, nil
-	case *bool:
-		if defaultValue == nil {
-			b := false
-			defaultValue = &b
-		}
-		return defaultValue, nil
-	}
-	// If you hit this then a non-boolean config setting is conflicting
-	// with one of Heka's defined boolean settings.
-	return nil, fmt.Errorf("%s config setting must be boolean", name)
-}
-
-func (m *pluginMaker) makeSplitterRunner(name string, splitter Splitter) (*sRunner, error) {
-	var err error
-	commonSplitter := m.commonTypedConfig.(CommonSplitterConfig)
-	if commonSplitter.KeepTruncated == nil {
-		commonSplitter.KeepTruncated, err = m.getDefaultBool("KeepTruncated")
-		if err != nil {
-			return nil, err
-		}
-	}
-	if commonSplitter.UseMsgBytes == nil {
-		commonSplitter.UseMsgBytes, err = m.getDefaultBool("UseMsgBytes")
-		if err != nil {
-			return nil, err
-		}
-	}
-	if commonSplitter.BufferSize == 0 {
-		bufferSize := getAttr(m.configStruct, "BufferSize", uint(8*1024))
-		commonSplitter.BufferSize = bufferSize.(uint)
-	}
-	if uint32(commonSplitter.BufferSize) > message.MAX_RECORD_SIZE {
-		err = fmt.Errorf("'min_buffer_size' (%d) can't be larger than MAX_RECORD_SIZE (%d)",
-			commonSplitter.BufferSize, message.MAX_RECORD_SIZE)
-		return nil, err
-	}
-	if commonSplitter.IncompleteFinal == nil {
-		commonSplitter.IncompleteFinal, err = m.getDefaultBool("IncompleteFinal")
-		if err != nil {
-			return nil, err
-		}
-	}
-	sr := NewSplitterRunner(name, splitter, commonSplitter)
-	return sr, nil
-}
-
-func (m *pluginMaker) makeInputRunner(name string, input Input, defaultTick uint) (
-	InputRunner, error) {
-
-	var err error
-	commonInput := m.commonTypedConfig.(CommonInputConfig)
-	if commonInput.Ticker == 0 {
-		commonInput.Ticker = defaultTick
-	}
-	if commonInput.SyncDecode == nil {
-		if commonInput.SyncDecode, err = m.getDefaultBool("SyncDecode"); err != nil {
-			return nil, err
-		}
-	}
-	if commonInput.SendDecodeFailures == nil {
-		commonInput.SendDecodeFailures, err = m.getDefaultBool("SendDecodeFailures")
-		if err != nil {
-			return nil, err
-		}
-	}
-	if commonInput.Decoder == "" {
-		decoder := getAttr(m.configStruct, "Decoder", "")
-		commonInput.Decoder = decoder.(string)
-	}
-	if commonInput.Splitter == "" {
-		splitter := getAttr(m.configStruct, "Splitter", "")
-		commonInput.Splitter = splitter.(string)
-	}
-	runner := NewInputRunner(name, input, commonInput)
-	return runner, nil
-}
-
-// MakeRunner returns a new, unstarted PluginRunner wrapped around a new,
-// configured plugin instance. If name is provided, then the Runner will be
-// given the specified name; if name is an empty string, the plugin name will
-// be used.
-func (m *pluginMaker) MakeRunner(name string) (PluginRunner, error) {
-	if m.category == "Encoder" {
-		return nil, fmt.Errorf("%s plugins don't support PluginRunners", m.category)
-	}
-
-	plugin, err := m.Make()
-	if err != nil {
-		return nil, err
-	}
-
-	if name == "" {
-		name = m.name
-	}
-
-	var runner PluginRunner
-
-	if m.category == "Decoder" {
-		runner = NewDecoderRunner(name, plugin.(Decoder), m.pConfig.Globals.PluginChanSize)
-		return runner, nil
-	}
-
-	if m.category == "Splitter" {
-		return m.makeSplitterRunner(name, plugin.(Splitter))
-	}
-
-	// In some cases a plugin implementation will specify a default value for
-	// one or more common config settings by including values for those
-	// settings in the config struct. We extract them in this function's outer
-	// scope, but we only need to use them if the common config hasn't already
-	// been populated by values from the TOML.
-	defaultTickerInterval := getAttr(m.configStruct, "TickerInterval", uint(0))
-	defaultTick := defaultTickerInterval.(uint)
-
-	if m.category == "Input" {
-		return m.makeInputRunner(name, plugin.(Input), defaultTick)
-	}
-
-	// We're a filter or an output.
-	commonFO := m.commonTypedConfig.(CommonFOConfig)
-
-	// More checks for plugin-specified default values of common config
-	// settings.
-	if commonFO.Matcher == "" {
-		matcherVal := getAttr(m.configStruct, "MessageMatcher", "")
-		commonFO.Matcher = matcherVal.(string)
-	}
-
-	if commonFO.Ticker == 0 {
-		commonFO.Ticker = defaultTick
-	}
-
-	// Boolean types are tricky, we use pointer types to distinguish btn false
-	// and not set, but a plugin's config struct might not be so smart, so we
-	// have to account for both cases.
-	if commonFO.CanExit == nil {
-		if commonFO.CanExit, err = m.getDefaultBool("CanExit"); err != nil {
-			return nil, err
-		}
-	}
-
-	if m.category == "Output" {
-		if commonFO.UseFraming == nil {
-			if commonFO.UseFraming, err = m.getDefaultBool("UseFraming"); err != nil {
-				return nil, err
-			}
-		}
-
-		if commonFO.Encoder == "" {
-			encoder := getAttr(m.configStruct, "Encoder", "")
-			commonFO.Encoder = encoder.(string)
-		}
-	}
-
-	return NewFORunner(name, plugin, commonFO, m.commonConfig.Typ,
-		m.pConfig.Globals.PluginChanSize)
-}
-
 // Default configurations.
 func makeDefaultConfigs() map[string]bool {
 	return map[string]bool{
@@ -1001,7 +590,7 @@ func (self *PipelineConfig) RegisterDefault(name string) error {
 		return err
 	}
 	LogInfo.Printf("Loading: [%s]\n", maker.Name())
-	if err = maker.PrepConfig(); err != nil {
+	if _, err = maker.PrepConfig(); err != nil {
 		return err
 	}
 	category := maker.Category()
@@ -1117,7 +706,7 @@ func (self *PipelineConfig) LoadConfig() error {
 	for _, category := range order {
 		for _, maker := range makersByCategory[category] {
 			LogInfo.Printf("Loading: [%s]\n", maker.Name())
-			if err = maker.PrepConfig(); err != nil {
+			if _, err = maker.PrepConfig(); err != nil {
 				self.log(err.Error())
 				self.errcnt++
 			}

--- a/pipeline/plugin_maker.go
+++ b/pipeline/plugin_maker.go
@@ -1,0 +1,438 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2015
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Rob Miller (rmiller@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/bbangert/toml"
+	"github.com/mozilla-services/heka/message"
+)
+
+type PluginMaker interface {
+	Name() string
+	Type() string
+	Category() string
+	Config() interface{}
+	PrepConfig() (interface{}, error)
+	Make() (Plugin, interface{}, error)
+	MakeRunner(name string) (PluginRunner, error)
+}
+
+// MutableMaker is for consumers that want to override the standard PluginMaker
+// behavior. Use at your own risk. Both interfaces are implemented by the same
+// struct, so a PluginMaker can be turned into a MutableMaker via type
+// coercion.
+type MutableMaker interface {
+	PluginMaker
+	OrigPrepConfig() (interface{}, error)
+	SetPrepConfig(func() (interface{}, error))
+	OrigPrepCommonTypedConfig() (interface{}, error)
+	SetPrepCommonTypedConfig(func() (interface{}, error))
+	SetName(name string)
+	SetType(typ string)
+	SetCategory(category string)
+}
+
+type pluginMaker struct {
+	name                  string
+	category              string
+	tomlSection           toml.Primitive
+	constructor           func() interface{}
+	commonConfig          CommonConfig
+	prepConfig            func() (interface{}, error)
+	prepCommonTypedConfig func() (interface{}, error)
+	pConfig               *PipelineConfig
+	plugin                Plugin
+}
+
+// NewPluginMaker creates and returns a PluginMaker that can generate running
+// plugins for the provided TOML configuration. It will load the plugin type
+// and extract any of the Heka-defined common config for the plugin before
+// returning.
+func NewPluginMaker(name string, pConfig *PipelineConfig, tomlSection toml.Primitive) (
+	PluginMaker, error) {
+
+	// Create the maker, extract plugin type, and make sure the plugin type
+	// exists.
+	maker := &pluginMaker{
+		name:         name,
+		tomlSection:  tomlSection,
+		commonConfig: CommonConfig{},
+		pConfig:      pConfig,
+	}
+
+	var err error
+	if err = toml.PrimitiveDecode(tomlSection, &maker.commonConfig); err != nil {
+		return nil, fmt.Errorf("can't decode common config for '%s': %s", name, err)
+	}
+	if maker.commonConfig.Typ == "" {
+		maker.commonConfig.Typ = name
+	}
+	constructor, ok := AvailablePlugins[maker.commonConfig.Typ]
+	if !ok {
+		return nil, fmt.Errorf("No registered plugin type: %s", maker.commonConfig.Typ)
+	}
+	maker.constructor = constructor
+	maker.plugin = maker.makePlugin() // Only used to generate config structs.
+
+	// Extract plugin category and any category-specific common (i.e. Heka
+	// defined) configuration.
+	maker.category = getPluginCategory(maker.commonConfig.Typ)
+	if maker.category == "" {
+		return nil, errors.New("Unrecognized plugin category")
+	}
+
+	maker.prepCommonTypedConfig = maker.OrigPrepCommonTypedConfig
+	_, err = maker.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't decode common %s config for '%s': %s",
+			strings.ToLower(maker.category), name, err)
+	}
+
+	maker.prepConfig = maker.OrigPrepConfig
+
+	return maker, nil
+}
+
+// OrigPrepCommonTypedConfig is the default implementation of the
+// `PrepCommonTypedConfig` function.
+func (m *pluginMaker) OrigPrepCommonTypedConfig() (interface{}, error) {
+	var (
+		commonTypedConfig interface{}
+		err               error
+	)
+	switch m.category {
+	case "Input":
+		commonInput := CommonInputConfig{
+			Retries: getDefaultRetryOptions(),
+		}
+		err = toml.PrimitiveDecode(m.tomlSection, &commonInput)
+		commonTypedConfig = commonInput
+	case "Filter", "Output":
+		commonFO := CommonFOConfig{
+			Retries: getDefaultRetryOptions(),
+		}
+		err = toml.PrimitiveDecode(m.tomlSection, &commonFO)
+		commonTypedConfig = commonFO
+	case "Splitter":
+		commonSplitter := CommonSplitterConfig{}
+		err = toml.PrimitiveDecode(m.tomlSection, &commonSplitter)
+		commonTypedConfig = commonSplitter
+	}
+	if err != nil {
+		return nil, err
+	}
+	return commonTypedConfig, nil
+}
+
+// PrepCommonTypedConfig returns a struct containing all of the common
+// configuration for the maker's plugin type, populated from the provided TOML.
+func (m *pluginMaker) PrepCommonTypedConfig() (interface{}, error) {
+	return m.prepCommonTypedConfig()
+}
+
+func (m *pluginMaker) Name() string {
+	return m.name
+}
+
+func (m *pluginMaker) Type() string {
+	return m.commonConfig.Typ
+}
+
+func (m *pluginMaker) Category() string {
+	return m.category
+}
+
+// SetPrepCommonTypedConfig allows plugins a mechanism for overriding
+// TOML-loaded config in the per-type common configuration settings.
+func (m *pluginMaker) SetPrepCommonTypedConfig(prepCommonTypedConfig func() (interface{}, error)) {
+	m.prepCommonTypedConfig = prepCommonTypedConfig
+}
+
+func (m *pluginMaker) SetName(name string) {
+	m.name = name
+}
+
+func (m *pluginMaker) SetType(typ string) {
+	m.commonConfig.Typ = typ
+}
+
+func (m *pluginMaker) SetCategory(category string) {
+	m.category = category
+}
+
+// makePlugin instantiates a plugin instance, provides name and pConfig to the
+// plugin if necessary, and returns the plugin.
+func (m *pluginMaker) makePlugin() Plugin {
+	plugin := m.constructor().(Plugin)
+	if wantsPConfig, ok := plugin.(WantsPipelineConfig); ok {
+		wantsPConfig.SetPipelineConfig(m.pConfig)
+	}
+	if wantsName, ok := plugin.(WantsName); ok {
+		wantsName.SetName(m.name)
+	}
+	return plugin
+}
+
+// Config uses the maker's cached plugin instance to create a config object.
+func (m *pluginMaker) Config() interface{} {
+	hasConfigStruct, ok := m.plugin.(HasConfigStruct)
+	if ok {
+		return hasConfigStruct.ConfigStruct()
+	} else {
+		// If we don't have a config struct, fall back to a PluginConfig.
+		return PluginConfig{}
+	}
+}
+
+// OrigPrepConfig is the default implementation of the `PrepConfig` method.
+func (m *pluginMaker) OrigPrepConfig() (interface{}, error) {
+	config := m.Config()
+	var err error
+
+	if _, ok := config.(PluginConfig); ok {
+		if err = toml.PrimitiveDecode(m.tomlSection, config); err != nil {
+			return nil, fmt.Errorf("can't decode config for '%s': %s", m.name, err.Error())
+		}
+		return config, nil
+	}
+
+	// Use reflection to extract the fields (or TOML tag names, if available)
+	// of the values that Heka has already extracted so we know they're not
+	// required to be specified in the config struct.
+	hekaParams := make(map[string]interface{})
+	commonTypedConfig, _ := m.OrigPrepCommonTypedConfig()
+	commons := []interface{}{m.commonConfig, commonTypedConfig}
+	for _, common := range commons {
+		if common == nil {
+			continue
+		}
+		rt := reflect.ValueOf(common).Type()
+		for i := 0; i < rt.NumField(); i++ {
+			sft := rt.Field(i)
+			kname := sft.Tag.Get("toml")
+			if len(kname) == 0 {
+				kname = sft.Name
+			}
+			hekaParams[kname] = true
+		}
+	}
+
+	// Finally decode the TOML into the struct. Use of PrimitiveDecodeStrict
+	// means that an error will be raised for any config options in the TOML
+	// that don't have corresponding attributes on the struct, delta the
+	// hekaParams that can be safely excluded.
+	err = toml.PrimitiveDecodeStrict(m.tomlSection, config, hekaParams)
+	if err != nil {
+		matches := unknownOptionRegex.FindStringSubmatch(err.Error())
+		if len(matches) == 2 {
+			// We've got an unrecognized config option.
+			err = fmt.Errorf("unknown config setting for '%s': %s", m.name, matches[1])
+		}
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// PrepConfig decodes the maker's TOML config into a newly created config struct.
+func (m *pluginMaker) PrepConfig() (interface{}, error) {
+	return m.prepConfig()
+}
+
+// SetPrepConfig provides plugins a mechanism to override the TOML-loaded
+// plugin specific configuration.
+func (m *pluginMaker) SetPrepConfig(prepConfig func() (interface{}, error)) {
+	m.prepConfig = prepConfig
+}
+
+// Make creates and returns a config struct and an initialized plugin.
+func (m *pluginMaker) Make() (Plugin, interface{}, error) {
+	config, err := m.prepConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plugin := m.makePlugin()
+	if err = plugin.Init(config); err != nil {
+		return nil, nil, fmt.Errorf("Initialization failed for '%s': %s", m.name, err)
+	}
+
+	return plugin, config, nil
+}
+
+func (m *pluginMaker) makeSplitterRunner(name string, config interface{}, splitter Splitter) (*sRunner, error) {
+	commonConfig, err := m.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())
+	}
+	commonSplitter := commonConfig.(CommonSplitterConfig)
+	if commonSplitter.KeepTruncated == nil {
+		commonSplitter.KeepTruncated, err = getDefaultBool(config, "KeepTruncated")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if commonSplitter.UseMsgBytes == nil {
+		commonSplitter.UseMsgBytes, err = getDefaultBool(config, "UseMsgBytes")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if commonSplitter.BufferSize == 0 {
+		bufferSize := getAttr(config, "BufferSize", uint(8*1024))
+		commonSplitter.BufferSize = bufferSize.(uint)
+	}
+	if uint32(commonSplitter.BufferSize) > message.MAX_RECORD_SIZE {
+		err = fmt.Errorf("'min_buffer_size' (%d) can't be larger than MAX_RECORD_SIZE (%d)",
+			commonSplitter.BufferSize, message.MAX_RECORD_SIZE)
+		return nil, err
+	}
+	if commonSplitter.IncompleteFinal == nil {
+		commonSplitter.IncompleteFinal, err = getDefaultBool(config, "IncompleteFinal")
+		if err != nil {
+			return nil, err
+		}
+	}
+	sr := NewSplitterRunner(name, splitter, commonSplitter)
+	return sr, nil
+}
+
+func (m *pluginMaker) makeInputRunner(name string, config interface{}, input Input,
+	defaultTick uint) (InputRunner, error) {
+
+	commonConfig, err := m.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())
+	}
+	commonInput := commonConfig.(CommonInputConfig)
+	if commonInput.Ticker == 0 {
+		commonInput.Ticker = defaultTick
+	}
+	if commonInput.SyncDecode == nil {
+		if commonInput.SyncDecode, err = getDefaultBool(config, "SyncDecode"); err != nil {
+			return nil, err
+		}
+	}
+	if commonInput.SendDecodeFailures == nil {
+		commonInput.SendDecodeFailures, err = getDefaultBool(config, "SendDecodeFailures")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if commonInput.CanExit == nil {
+		if commonInput.CanExit, err = getDefaultBool(config, "CanExit"); err != nil {
+			return nil, err
+		}
+	}
+	if commonInput.Decoder == "" {
+		decoder := getAttr(config, "Decoder", "")
+		commonInput.Decoder = decoder.(string)
+	}
+	if commonInput.Splitter == "" {
+		splitter := getAttr(config, "Splitter", "")
+		commonInput.Splitter = splitter.(string)
+	}
+	runner := NewInputRunner(name, input, commonInput)
+	return runner, nil
+}
+
+// MakeRunner returns a new, unstarted PluginRunner wrapped around a new,
+// configured plugin instance. If name is provided, then the Runner will be
+// given the specified name; if name is an empty string, the plugin name will
+// be used.
+func (m *pluginMaker) MakeRunner(name string) (PluginRunner, error) {
+	if m.category == "Encoder" {
+		return nil, fmt.Errorf("%s plugins don't support PluginRunners", m.category)
+	}
+
+	plugin, config, err := m.Make()
+	if err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		name = m.name
+	}
+
+	var runner PluginRunner
+
+	if m.category == "Decoder" {
+		runner = NewDecoderRunner(name, plugin.(Decoder), m.pConfig.Globals.PluginChanSize)
+		return runner, nil
+	}
+
+	if m.category == "Splitter" {
+		return m.makeSplitterRunner(name, config, plugin.(Splitter))
+	}
+
+	// In some cases a plugin implementation will specify a default value for
+	// one or more common config settings by including values for those
+	// settings in the config struct. We extract them in this function's outer
+	// scope, but we only need to use them if the common config hasn't already
+	// been populated by values from the TOML.
+	defaultTickerInterval := getAttr(config, "TickerInterval", uint(0))
+	defaultTick := defaultTickerInterval.(uint)
+
+	if m.category == "Input" {
+		return m.makeInputRunner(name, config, plugin.(Input), defaultTick)
+	}
+
+	// We're a filter or an output.
+	commonConfig, err := m.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())
+	}
+
+	commonFO := commonConfig.(CommonFOConfig)
+	// More checks for plugin-specified default values of common config
+	// settings.
+	if commonFO.Matcher == "" {
+		matcherVal := getAttr(config, "MessageMatcher", "")
+		commonFO.Matcher = matcherVal.(string)
+	}
+
+	if commonFO.Ticker == 0 {
+		commonFO.Ticker = defaultTick
+	}
+
+	// Boolean types are tricky, we use pointer types to distinguish btn false
+	// and not set, but a plugin's config struct might not be so smart, so we
+	// have to account for both cases.
+	if commonFO.CanExit == nil {
+		if commonFO.CanExit, err = getDefaultBool(config, "CanExit"); err != nil {
+			return nil, err
+		}
+	}
+
+	if m.category == "Output" {
+		if commonFO.UseFraming == nil {
+			if commonFO.UseFraming, err = getDefaultBool(config, "UseFraming"); err != nil {
+				return nil, err
+			}
+		}
+		if commonFO.Encoder == "" {
+			encoder := getAttr(config, "Encoder", "")
+			commonFO.Encoder = encoder.(string)
+		}
+	}
+
+	return NewFORunner(name, plugin, commonFO, m.commonConfig.Typ,
+		m.pConfig.Globals.PluginChanSize)
+}

--- a/pipeline/plugin_maker.go
+++ b/pipeline/plugin_maker.go
@@ -1,0 +1,434 @@
+/***** BEGIN LICENSE BLOCK *****
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# The Initial Developer of the Original Code is the Mozilla Foundation.
+# Portions created by the Initial Developer are Copyright (C) 2015
+# the Initial Developer. All Rights Reserved.
+#
+# Contributor(s):
+#   Rob Miller (rmiller@mozilla.com)
+#
+# ***** END LICENSE BLOCK *****/
+
+package pipeline
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/bbangert/toml"
+	"github.com/mozilla-services/heka/message"
+)
+
+type PluginMaker interface {
+	Name() string
+	Type() string
+	Category() string
+	Config() interface{}
+	PrepConfig() (interface{}, error)
+	Make() (Plugin, interface{}, error)
+	MakeRunner(name string) (PluginRunner, error)
+}
+
+// MutableMaker is for consumers that want to override the standard PluginMaker
+// behavior. Use at your own risk. Both interfaces are implemented by the same
+// struct, so a PluginMaker can be turned into a MutableMaker via type
+// coercion.
+type MutableMaker interface {
+	PluginMaker
+	OrigPrepConfig() (interface{}, error)
+	SetPrepConfig(func() (interface{}, error))
+	OrigPrepCommonTypedConfig() (interface{}, error)
+	SetPrepCommonTypedConfig(func() (interface{}, error))
+	SetName(name string)
+	SetType(typ string)
+	SetCategory(category string)
+}
+
+type pluginMaker struct {
+	name                  string
+	category              string
+	tomlSection           toml.Primitive
+	constructor           func() interface{}
+	commonConfig          CommonConfig
+	prepConfig            func() (interface{}, error)
+	prepCommonTypedConfig func() (interface{}, error)
+	pConfig               *PipelineConfig
+	plugin                Plugin
+}
+
+// NewPluginMaker creates and returns a PluginMaker that can generate running
+// plugins for the provided TOML configuration. It will load the plugin type
+// and extract any of the Heka-defined common config for the plugin before
+// returning.
+func NewPluginMaker(name string, pConfig *PipelineConfig, tomlSection toml.Primitive) (
+	PluginMaker, error) {
+
+	// Create the maker, extract plugin type, and make sure the plugin type
+	// exists.
+	maker := &pluginMaker{
+		name:         name,
+		tomlSection:  tomlSection,
+		commonConfig: CommonConfig{},
+		pConfig:      pConfig,
+	}
+
+	var err error
+	if err = toml.PrimitiveDecode(tomlSection, &maker.commonConfig); err != nil {
+		return nil, fmt.Errorf("can't decode common config for '%s': %s", name, err)
+	}
+	if maker.commonConfig.Typ == "" {
+		maker.commonConfig.Typ = name
+	}
+	constructor, ok := AvailablePlugins[maker.commonConfig.Typ]
+	if !ok {
+		return nil, fmt.Errorf("No registered plugin type: %s", maker.commonConfig.Typ)
+	}
+	maker.constructor = constructor
+	maker.plugin = maker.makePlugin() // Only used to generate config structs.
+
+	// Extract plugin category and any category-specific common (i.e. Heka
+	// defined) configuration.
+	maker.category = getPluginCategory(maker.commonConfig.Typ)
+	if maker.category == "" {
+		return nil, errors.New("Unrecognized plugin category")
+	}
+
+	maker.prepCommonTypedConfig = maker.OrigPrepCommonTypedConfig
+	_, err = maker.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't decode common %s config for '%s': %s",
+			strings.ToLower(maker.category), name, err)
+	}
+
+	maker.prepConfig = maker.OrigPrepConfig
+
+	return maker, nil
+}
+
+// OrigPrepCommonTypedConfig is the default implementation of the
+// `PrepCommonTypedConfig` function.
+func (m *pluginMaker) OrigPrepCommonTypedConfig() (interface{}, error) {
+	var (
+		commonTypedConfig interface{}
+		err               error
+	)
+	switch m.category {
+	case "Input":
+		commonInput := CommonInputConfig{
+			Retries: getDefaultRetryOptions(),
+		}
+		err = toml.PrimitiveDecode(m.tomlSection, &commonInput)
+		commonTypedConfig = commonInput
+	case "Filter", "Output":
+		commonFO := CommonFOConfig{
+			Retries: getDefaultRetryOptions(),
+		}
+		err = toml.PrimitiveDecode(m.tomlSection, &commonFO)
+		commonTypedConfig = commonFO
+	case "Splitter":
+		commonSplitter := CommonSplitterConfig{}
+		err = toml.PrimitiveDecode(m.tomlSection, &commonSplitter)
+		commonTypedConfig = commonSplitter
+	}
+	if err != nil {
+		return nil, err
+	}
+	return commonTypedConfig, nil
+}
+
+// PrepCommonTypedConfig returns a struct containing all of the common
+// configuration for the maker's plugin type, populated from the provided TOML.
+func (m *pluginMaker) PrepCommonTypedConfig() (interface{}, error) {
+	return m.prepCommonTypedConfig()
+}
+
+func (m *pluginMaker) Name() string {
+	return m.name
+}
+
+func (m *pluginMaker) Type() string {
+	return m.commonConfig.Typ
+}
+
+func (m *pluginMaker) Category() string {
+	return m.category
+}
+
+// SetPrepCommonTypedConfig allows plugins a mechanism for overriding
+// TOML-loaded config in the per-type common configuration settings.
+func (m *pluginMaker) SetPrepCommonTypedConfig(prepCommonTypedConfig func() (interface{}, error)) {
+	m.prepCommonTypedConfig = prepCommonTypedConfig
+}
+
+func (m *pluginMaker) SetName(name string) {
+	m.name = name
+}
+
+func (m *pluginMaker) SetType(typ string) {
+	m.commonConfig.Typ = typ
+}
+
+func (m *pluginMaker) SetCategory(category string) {
+	m.category = category
+}
+
+// makePlugin instantiates a plugin instance, provides name and pConfig to the
+// plugin if necessary, and returns the plugin.
+func (m *pluginMaker) makePlugin() Plugin {
+	plugin := m.constructor().(Plugin)
+	if wantsPConfig, ok := plugin.(WantsPipelineConfig); ok {
+		wantsPConfig.SetPipelineConfig(m.pConfig)
+	}
+	if wantsName, ok := plugin.(WantsName); ok {
+		wantsName.SetName(m.name)
+	}
+	return plugin
+}
+
+// Config uses the maker's cached plugin instance to create a config object.
+func (m *pluginMaker) Config() interface{} {
+	hasConfigStruct, ok := m.plugin.(HasConfigStruct)
+	if ok {
+		return hasConfigStruct.ConfigStruct()
+	} else {
+		// If we don't have a config struct, fall back to a PluginConfig.
+		return PluginConfig{}
+	}
+}
+
+// OrigPrepConfig is the default implementation of the `PrepConfig` method.
+func (m *pluginMaker) OrigPrepConfig() (interface{}, error) {
+	config := m.Config()
+	var err error
+
+	if _, ok := config.(PluginConfig); ok {
+		if err = toml.PrimitiveDecode(m.tomlSection, config); err != nil {
+			return nil, fmt.Errorf("can't decode config for '%s': %s", m.name, err.Error())
+		}
+		return config, nil
+	}
+
+	// Use reflection to extract the fields (or TOML tag names, if available)
+	// of the values that Heka has already extracted so we know they're not
+	// required to be specified in the config struct.
+	hekaParams := make(map[string]interface{})
+	commonTypedConfig, _ := m.OrigPrepCommonTypedConfig()
+	commons := []interface{}{m.commonConfig, commonTypedConfig}
+	for _, common := range commons {
+		if common == nil {
+			continue
+		}
+		rt := reflect.ValueOf(common).Type()
+		for i := 0; i < rt.NumField(); i++ {
+			sft := rt.Field(i)
+			kname := sft.Tag.Get("toml")
+			if len(kname) == 0 {
+				kname = sft.Name
+			}
+			hekaParams[kname] = true
+		}
+	}
+
+	// Finally decode the TOML into the struct. Use of PrimitiveDecodeStrict
+	// means that an error will be raised for any config options in the TOML
+	// that don't have corresponding attributes on the struct, delta the
+	// hekaParams that can be safely excluded.
+	err = toml.PrimitiveDecodeStrict(m.tomlSection, config, hekaParams)
+	if err != nil {
+		matches := unknownOptionRegex.FindStringSubmatch(err.Error())
+		if len(matches) == 2 {
+			// We've got an unrecognized config option.
+			err = fmt.Errorf("unknown config setting for '%s': %s", m.name, matches[1])
+		}
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// PrepConfig decodes the maker's TOML config into a newly created config struct.
+func (m *pluginMaker) PrepConfig() (interface{}, error) {
+	return m.prepConfig()
+}
+
+// SetPrepConfig provides plugins a mechanism to override the TOML-loaded
+// plugin specific configuration.
+func (m *pluginMaker) SetPrepConfig(prepConfig func() (interface{}, error)) {
+	m.prepConfig = prepConfig
+}
+
+// Make creates and returns a config struct and an initialized plugin.
+func (m *pluginMaker) Make() (Plugin, interface{}, error) {
+	config, err := m.prepConfig()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plugin := m.makePlugin()
+	if err = plugin.Init(config); err != nil {
+		return nil, nil, fmt.Errorf("Initialization failed for '%s': %s", m.name, err)
+	}
+
+	return plugin, config, nil
+}
+
+func (m *pluginMaker) makeSplitterRunner(name string, config interface{}, splitter Splitter) (*sRunner, error) {
+	commonConfig, err := m.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())
+	}
+	commonSplitter := commonConfig.(CommonSplitterConfig)
+	if commonSplitter.KeepTruncated == nil {
+		commonSplitter.KeepTruncated, err = getDefaultBool(config, "KeepTruncated")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if commonSplitter.UseMsgBytes == nil {
+		commonSplitter.UseMsgBytes, err = getDefaultBool(config, "UseMsgBytes")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if commonSplitter.BufferSize == 0 {
+		bufferSize := getAttr(config, "BufferSize", uint(8*1024))
+		commonSplitter.BufferSize = bufferSize.(uint)
+	}
+	if uint32(commonSplitter.BufferSize) > message.MAX_RECORD_SIZE {
+		err = fmt.Errorf("'min_buffer_size' (%d) can't be larger than MAX_RECORD_SIZE (%d)",
+			commonSplitter.BufferSize, message.MAX_RECORD_SIZE)
+		return nil, err
+	}
+	if commonSplitter.IncompleteFinal == nil {
+		commonSplitter.IncompleteFinal, err = getDefaultBool(config, "IncompleteFinal")
+		if err != nil {
+			return nil, err
+		}
+	}
+	sr := NewSplitterRunner(name, splitter, commonSplitter)
+	return sr, nil
+}
+
+func (m *pluginMaker) makeInputRunner(name string, config interface{}, input Input,
+	defaultTick uint) (InputRunner, error) {
+
+	fmt.Println("Before fetching")
+	commonConfig, err := m.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())
+	}
+	commonInput := commonConfig.(CommonInputConfig)
+	if commonInput.Ticker == 0 {
+		commonInput.Ticker = defaultTick
+	}
+	if commonInput.SyncDecode == nil {
+		if commonInput.SyncDecode, err = getDefaultBool(config, "SyncDecode"); err != nil {
+			return nil, err
+		}
+	}
+	if commonInput.SendDecodeFailures == nil {
+		commonInput.SendDecodeFailures, err = getDefaultBool(config, "SendDecodeFailures")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if commonInput.Decoder == "" {
+		decoder := getAttr(config, "Decoder", "")
+		commonInput.Decoder = decoder.(string)
+	}
+	if commonInput.Splitter == "" {
+		splitter := getAttr(config, "Splitter", "")
+		commonInput.Splitter = splitter.(string)
+	}
+	runner := NewInputRunner(name, input, commonInput)
+	return runner, nil
+}
+
+// MakeRunner returns a new, unstarted PluginRunner wrapped around a new,
+// configured plugin instance. If name is provided, then the Runner will be
+// given the specified name; if name is an empty string, the plugin name will
+// be used.
+func (m *pluginMaker) MakeRunner(name string) (PluginRunner, error) {
+	if m.category == "Encoder" {
+		return nil, fmt.Errorf("%s plugins don't support PluginRunners", m.category)
+	}
+
+	plugin, config, err := m.Make()
+	if err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		name = m.name
+	}
+
+	var runner PluginRunner
+
+	if m.category == "Decoder" {
+		runner = NewDecoderRunner(name, plugin.(Decoder), m.pConfig.Globals.PluginChanSize)
+		return runner, nil
+	}
+
+	if m.category == "Splitter" {
+		return m.makeSplitterRunner(name, config, plugin.(Splitter))
+	}
+
+	// In some cases a plugin implementation will specify a default value for
+	// one or more common config settings by including values for those
+	// settings in the config struct. We extract them in this function's outer
+	// scope, but we only need to use them if the common config hasn't already
+	// been populated by values from the TOML.
+	defaultTickerInterval := getAttr(config, "TickerInterval", uint(0))
+	defaultTick := defaultTickerInterval.(uint)
+
+	if m.category == "Input" {
+		return m.makeInputRunner(name, config, plugin.(Input), defaultTick)
+	}
+
+	// We're a filter or an output.
+	commonConfig, err := m.prepCommonTypedConfig()
+	if err != nil {
+		return nil, fmt.Errorf("Can't prep common typed config: %s", err.Error())
+	}
+
+	commonFO := commonConfig.(CommonFOConfig)
+	// More checks for plugin-specified default values of common config
+	// settings.
+	if commonFO.Matcher == "" {
+		matcherVal := getAttr(config, "MessageMatcher", "")
+		commonFO.Matcher = matcherVal.(string)
+	}
+
+	if commonFO.Ticker == 0 {
+		commonFO.Ticker = defaultTick
+	}
+
+	// Boolean types are tricky, we use pointer types to distinguish btn false
+	// and not set, but a plugin's config struct might not be so smart, so we
+	// have to account for both cases.
+	if commonFO.CanExit == nil {
+		if commonFO.CanExit, err = getDefaultBool(config, "CanExit"); err != nil {
+			return nil, err
+		}
+	}
+
+	if m.category == "Output" {
+		if commonFO.UseFraming == nil {
+			if commonFO.UseFraming, err = getDefaultBool(config, "UseFraming"); err != nil {
+				return nil, err
+			}
+		}
+		if commonFO.Encoder == "" {
+			encoder := getAttr(config, "Encoder", "")
+			commonFO.Encoder = encoder.(string)
+		}
+	}
+
+	return NewFORunner(name, plugin, commonFO, m.commonConfig.Typ,
+		m.pConfig.Globals.PluginChanSize)
+}

--- a/pipeline/plugin_runners_test.go
+++ b/pipeline/plugin_runners_test.go
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012-2014
+# Portions created by the Initial Developer are Copyright (C) 2012-2015
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
@@ -19,11 +19,12 @@ package pipeline
 import (
 	"bytes"
 	"errors"
+	"sync"
+
 	"github.com/mozilla-services/heka/message"
 	ts "github.com/mozilla-services/heka/pipeline/testsupport"
 	"github.com/rafrombrc/gomock/gomock"
 	gs "github.com/rafrombrc/gospec/src/gospec"
-	"sync"
 )
 
 var stopinputTimes int
@@ -64,13 +65,15 @@ func InputRunnerSpec(c gs.Context) {
 	decoder := &_fooDecoder{}
 
 	decoderMaker := &pluginMaker{
-		name:          "FooDecoder",
-		category:      "Decoder",
-		pConfig:       pConfig,
-		configPrepped: true,
+		name:     "FooDecoder",
+		category: "Decoder",
+		pConfig:  pConfig,
 	}
 	decoderMaker.constructor = func() interface{} {
 		return decoder
+	}
+	decoderMaker.prepConfig = func() (interface{}, error) {
+		return make(map[string]interface{}), nil
 	}
 	pConfig.DecoderMakers["FooDecoder"] = decoderMaker
 
@@ -99,7 +102,9 @@ func InputRunnerSpec(c gs.Context) {
 			mockHelper.EXPECT().PipelineConfig().Return(pConfig)
 			input := &StoppingInput{}
 			maker := &pluginMaker{}
-			maker.configStruct = make(map[string]interface{})
+			maker.prepConfig = func() (interface{}, error) {
+				return make(map[string]interface{}), nil
+			}
 			runner := NewInputRunner("stopping", input, commonInput).(*iRunner)
 			runner.maker = maker
 			startRunner(runner)
@@ -317,7 +322,9 @@ func OutputRunnerSpec(c gs.Context) {
 		}
 		chanSize := 10
 		maker := &pluginMaker{}
-		maker.configStruct = make(map[string]interface{})
+		maker.prepConfig = func() (interface{}, error) {
+			return make(map[string]interface{}), nil
+		}
 		pConfig.makers["Output"]["stoppingOutput"] = maker
 
 		c.Specify("restarts a plugin on the first time only", func() {

--- a/plugins/http/http_input_test.go
+++ b/plugins/http/http_input_test.go
@@ -16,14 +16,15 @@
 package http
 
 import (
+	"io"
+	"time"
+
 	. "github.com/mozilla-services/heka/pipeline"
 	pipeline_ts "github.com/mozilla-services/heka/pipeline/testsupport"
 	"github.com/mozilla-services/heka/pipelinemock"
 	plugins_ts "github.com/mozilla-services/heka/plugins/testsupport"
 	"github.com/rafrombrc/gomock/gomock"
 	gs "github.com/rafrombrc/gospec/src/gospec"
-	"io"
-	"time"
 )
 
 func HttpInputSpec(c gs.Context) {
@@ -142,13 +143,18 @@ func HttpInputSpec(c gs.Context) {
 
 		c.Specify("supports configuring HTTP headers", func() {
 			// Spin up a http server which expects requests with method "POST"
-			server, err := plugins_ts.NewHttpHeadersServer(map[string]string{"Accept": "text/plain"}, "localhost", 9873)
+			headers := map[string]string{
+				"Accept":     "text/plain",
+				"user-agent": "CustomUserAgent",
+			}
+
+			server, err := plugins_ts.NewHttpHeadersServer(headers, "localhost", 9873)
 			c.Expect(err, gs.IsNil)
 			go server.Start("/HeadersTest")
 			time.Sleep(10 * time.Millisecond)
 
 			config.Url = "http://localhost:9873/HeadersTest"
-			config.Headers = map[string]string{"Accept": "text/plain"}
+			config.Headers = headers
 
 			err = httpInput.Init(config)
 			c.Assume(err, gs.IsNil)

--- a/plugins/process/process_directory_input.go
+++ b/plugins/process/process_directory_input.go
@@ -18,12 +18,13 @@ package process
 import (
 	"errors"
 	"fmt"
-	"github.com/bbangert/toml"
-	. "github.com/mozilla-services/heka/pipeline"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/bbangert/toml"
+	. "github.com/mozilla-services/heka/pipeline"
 )
 
 type ProcessEntry struct {
@@ -201,16 +202,25 @@ func (pdi *ProcessDirectoryInput) procDirWalkFunc(path string, info os.FileInfo,
 		pdi.ir.LogError(fmt.Errorf("loading process file '%s': %s", path, err))
 		return nil
 	}
-	// Override the config settings we manage, make the runner, and store the entry.
-	entry.config.TickerInterval = uint(tickInterval)
 
-	commonConfig := entry.maker.CommonTypedConfig().(CommonInputConfig)
-	commonConfig.Retries = RetryOptions{
-		MaxDelay:   "30s",
-		Delay:      "250ms",
-		MaxRetries: -1,
+	// Override the config settings we manage, make the runner, and store the
+	// entry.
+	prepConfig := func() (interface{}, error) {
+		config, err := entry.maker.OrigPrepConfig()
+		if err != nil {
+			return nil, err
+		}
+		processInputConfig := config.(*ProcessInputConfig)
+		processInputConfig.TickerInterval = uint(tickInterval)
+		return processInputConfig, nil
 	}
-	entry.maker.SetCommonTypedConfig(commonConfig)
+	config, err := prepConfig()
+	if err != nil {
+		pdi.ir.LogError(fmt.Errorf("prepping config: %s", err.Error()))
+		return nil
+	}
+	entry.config = config.(*ProcessInputConfig)
+	entry.maker.SetPrepConfig(prepConfig)
 
 	runner, err := entry.maker.MakeRunner("")
 	if err != nil {
@@ -242,13 +252,24 @@ func (pdi *ProcessDirectoryInput) loadProcessFile(path string) (*ProcessEntry, e
 
 	mutMaker := maker.(MutableMaker)
 	mutMaker.SetName(path)
-	if err = mutMaker.PrepConfig(); err != nil {
-		return nil, fmt.Errorf("can't prep config: %s", err)
+
+	prepCommonTypedConfig := func() (interface{}, error) {
+		commonTypedConfig, err := mutMaker.OrigPrepCommonTypedConfig()
+		if err != nil {
+			return nil, err
+		}
+		commonInput := commonTypedConfig.(CommonInputConfig)
+		commonInput.Retries = RetryOptions{
+			MaxDelay:   "30s",
+			Delay:      "250ms",
+			MaxRetries: -1,
+		}
+		return commonInput, nil
 	}
+	mutMaker.SetPrepCommonTypedConfig(prepCommonTypedConfig)
 
 	entry := &ProcessEntry{
-		maker:  mutMaker,
-		config: mutMaker.Config().(*ProcessInputConfig),
+		maker: mutMaker,
 	}
 	return entry, nil
 }

--- a/sandbox/plugins/sandbox_filter.go
+++ b/sandbox/plugins/sandbox_filter.go
@@ -325,6 +325,7 @@ func (this *SandboxFilter) Run(fr pipeline.FilterRunner, h pipeline.PluginHelper
 				pack.Message.SetPayload(this.sb.LastError())
 			}
 			fr.Inject(pack)
+			err = pipeline.TerminatedError(this.sb.LastError())
 			break
 		}
 	}
@@ -349,9 +350,10 @@ func (this *SandboxFilter) Run(fr pipeline.FilterRunner, h pipeline.PluginHelper
 	}
 	if destroyErr != nil {
 		if err != nil {
-			fr.LogError(err)
+			fr.LogError(destroyErr)
+		} else {
+			err = destroyErr
 		}
-		err = destroyErr
 	}
 
 	this.sb = nil

--- a/sandbox/plugins/sandbox_filters_test.go
+++ b/sandbox/plugins/sandbox_filters_test.go
@@ -2,6 +2,10 @@ package plugins
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
 	"github.com/mozilla-services/heka/message"
 	"github.com/mozilla-services/heka/pipeline"
 	ts "github.com/mozilla-services/heka/pipeline/testsupport"
@@ -9,9 +13,6 @@ import (
 	"github.com/mozilla-services/heka/sandbox"
 	"github.com/rafrombrc/gomock/gomock"
 	gs "github.com/rafrombrc/gospec/src/gospec"
-	"os"
-	"path/filepath"
-	"time"
 )
 
 type FilterTestHelper struct {

--- a/sandbox/plugins/sandbox_filters_test.go
+++ b/sandbox/plugins/sandbox_filters_test.go
@@ -67,7 +67,7 @@ func FilterSpec(c gs.Context) {
 			inChan <- pack
 			close(inChan)
 			err = sbFilter.Run(fth.MockFilterRunner, fth.MockHelper)
-			termErr := pipeline.TerminatedError("exceeded InjectMessage count")
+			termErr := pipeline.TerminatedError("process_message() ../lua/testsupport/processinject.lua:8: inject_payload() exceeded InjectMessage count")
 			c.Expect(err.Error(), gs.Equals, termErr.Error())
 		})
 
@@ -89,7 +89,7 @@ func FilterSpec(c gs.Context) {
 				close(inChan)
 			}()
 			err = sbFilter.Run(fth.MockFilterRunner, fth.MockHelper)
-			termErr := pipeline.TerminatedError("exceeded InjectMessage count")
+			termErr := pipeline.TerminatedError("timer_event() ../lua/testsupport/timerinject.lua:13: inject_payload() exceeded InjectMessage count")
 			c.Expect(err.Error(), gs.Equals, termErr.Error())
 		})
 

--- a/sandbox/plugins/sandbox_manager_filter.go
+++ b/sandbox/plugins/sandbox_manager_filter.go
@@ -247,7 +247,6 @@ func (this *SandboxManagerFilter) restoreSandboxes(fr pipeline.FilterRunner,
 	glob := fmt.Sprintf("%s-*.toml", getNormalizedName(fr.Name()))
 	if matches, err := filepath.Glob(filepath.Join(dir, glob)); err == nil {
 		for _, fn := range matches {
-			fmt.Println("match fn: ", fn)
 			var configFile pipeline.ConfigFile
 			if _, err = toml.DecodeFile(fn, &configFile); err != nil {
 				fr.LogError(fmt.Errorf("restoreSandboxes failed: %s\n", err))

--- a/sandbox/plugins/sandbox_manager_filter.go
+++ b/sandbox/plugins/sandbox_manager_filter.go
@@ -4,7 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 #
 # The Initial Developer of the Original Code is the Mozilla Foundation.
-# Portions created by the Initial Developer are Copyright (C) 2012-2014
+# Portions created by the Initial Developer are Copyright (C) 2012-2015
 # the Initial Developer. All Rights Reserved.
 #
 # Contributor(s):
@@ -17,10 +17,6 @@ package plugins
 
 import (
 	"fmt"
-	"github.com/bbangert/toml"
-	"github.com/mozilla-services/heka/message"
-	"github.com/mozilla-services/heka/pipeline"
-	. "github.com/mozilla-services/heka/sandbox"
 	"io/ioutil"
 	"math"
 	"os"
@@ -29,6 +25,11 @@ import (
 	"regexp"
 	"sync/atomic"
 	"time"
+
+	"github.com/bbangert/toml"
+	"github.com/mozilla-services/heka/message"
+	"github.com/mozilla-services/heka/pipeline"
+	. "github.com/mozilla-services/heka/sandbox"
 )
 
 // Heka Filter plugin that listens for (signed) control messages and
@@ -129,22 +130,24 @@ func (this *SandboxManagerFilter) createRunner(dir, name string, configSection t
 			maker.Type())
 	}
 
-	// First load the config that the user specified into the filter's config
-	// struct.
-	if err = maker.PrepConfig(); err != nil {
-		return nil, fmt.Errorf("Error prepping config: %s", err.Error())
-	}
-	// Then override some of the user provided settings with the manager
-	// settings.
+	// Customize the PrepConfig method so we can override any specified
+	// settings with the manager's settings.
 	mutMaker := maker.(pipeline.MutableMaker)
-	conf := mutMaker.Config().(*SandboxConfig)
-	conf.ScriptFilename = filepath.Join(dir, fmt.Sprintf("%s.%s", name, conf.ScriptType))
-	conf.ModuleDirectory = this.moduleDirectory
-	conf.MemoryLimit = this.memoryLimit
-	conf.InstructionLimit = this.instructionLimit
-	conf.OutputLimit = this.outputLimit
-	conf.PluginType = "filter"
-	mutMaker.SetConfig(conf)
+	prepConfig := func() (interface{}, error) {
+		config, err := mutMaker.OrigPrepConfig()
+		if err != nil {
+			return nil, err
+		}
+		conf := config.(*SandboxConfig)
+		conf.ScriptFilename = filepath.Join(dir, fmt.Sprintf("%s.%s", name, conf.ScriptType))
+		conf.ModuleDirectory = this.moduleDirectory
+		conf.MemoryLimit = this.memoryLimit
+		conf.InstructionLimit = this.instructionLimit
+		conf.OutputLimit = this.outputLimit
+		conf.PluginType = "filter"
+		return conf, nil
+	}
+	mutMaker.SetPrepConfig(prepConfig)
 
 	// Finally call MakeRunner() to initialize the plugin and create the
 	// runner.
@@ -244,6 +247,7 @@ func (this *SandboxManagerFilter) restoreSandboxes(fr pipeline.FilterRunner,
 	glob := fmt.Sprintf("%s-*.toml", getNormalizedName(fr.Name()))
 	if matches, err := filepath.Glob(filepath.Join(dir, glob)); err == nil {
 		for _, fn := range matches {
+			fmt.Println("match fn: ", fn)
 			var configFile pipeline.ConfigFile
 			if _, err = toml.DecodeFile(fn, &configFile); err != nil {
 				fr.LogError(fmt.Errorf("restoreSandboxes failed: %s\n", err))


### PR DESCRIPTION
This pull request allow to set in the DockerLogInput a configuration to set the ContainerName using an arbitrary environment variable defined inside the container. Refers to issue https://github.com/mozilla-services/heka/issues/1545

If the environment variable defined on the configuration is not set, it uses the ContainerName instead.

Added on the configuration a new entry name_from_env_var that allows to select the desired variable to use.

Sample configuration: 

(This sample is useful to get the mesos task id instead of the container name, since using Mesos/Marathon the container name does not match the marathon id)

``` toml
[hekad]
maxprocs = 2

[Dashboard]
type = "DashboardOutput"
address = ":4352"
ticker_interval = 15

[DockerLogInput]
name_from_env_var = "MESOS_TASK_ID"

[influxdb]
type = "SandboxEncoder"
filename = "lua_encoders/schema_influx.lua"

    [influxdb.config]
    series = "docker"
    skip_fields = "Pid EnvVersion Severity Type"

[InfluxOutput]
message_matcher = "Type == 'DockerLog'"
encoder = "influxdb"
type = "HttpOutput"
address = "http://10.10.10.10:31002/db/logs/series"
username = "root"
password = "root"
```
